### PR TITLE
Spall Format v3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ build/
 .vs/
 */.vs/
 .DS_Store
+*.ll
+*.spall
+examples/manual_tracing/build.sh
+examples/manual_tracing/hello

--- a/examples/auto_tracing/instrument.c
+++ b/examples/auto_tracing/instrument.c
@@ -39,7 +39,6 @@ typedef struct {
 static SpallProfile spall_ctx;
 static _Thread_local SpallBuffer spall_buffer;
 static _Thread_local AddrHash addr_map;
-static _Thread_local uint32_t tid;
 static _Thread_local bool spall_thread_running = false;
 
 // we're not checking overflow here...Don't do stupid things with input sizes
@@ -127,6 +126,10 @@ SPALL_FN bool ah_get(AddrHash *ah, void *addr, Name *name_ret) {
 #include <asm/unistd.h>
 #include <sys/mman.h>
 
+SPALL_FN uint64_t get_ticks(void) {
+	return __rdtsc();
+}
+
 SPALL_FN uint64_t mul_u64_u32_shr(uint64_t cyc, uint32_t mult, uint32_t shift) {
     __uint128_t x = cyc;
     x *= mult;
@@ -139,7 +142,7 @@ SPALL_FN long perf_event_open(struct perf_event_attr *hw_event, pid_t pid,
     return syscall(__NR_perf_event_open, hw_event, pid, cpu, group_fd, flags);
 }
 
-SPALL_FN double get_rdtsc_multiplier() {
+SPALL_FN double get_tick_multiplier() {
 	struct perf_event_attr pe = {
         .type = PERF_TYPE_HARDWARE,
         .size = sizeof(struct perf_event_attr),
@@ -171,26 +174,42 @@ SPALL_FN double get_rdtsc_multiplier() {
 #include <sys/types.h>
 #include <sys/sysctl.h>
 
-SPALL_FN double get_rdtsc_multiplier() {
-	uint64_t freq;
+SPALL_FN uint64_t get_ticks(void) {
+    uint64_t timer_val;
+
+#if defined(__x86_64__)
+	timer_val = __rdtsc();
+#elif defined(__aarch64__)
+    asm volatile("mrs %0, cntvct_el0;" : "=r"(timer_val) :: "memory");
+#endif
+
+    return timer_val;
+}
+
+SPALL_FN double get_tick_multiplier(void) {
+    uint64_t freq;
+
+#if defined(__x86_64)
 	size_t size = sizeof(freq);
-
 	sysctlbyname("machdep.tsc.frequency", &freq, &size, NULL, 0);
+#elif defined(__aarch64__)
+    asm volatile("mrs %0, cntfrq_el0" : "=r"(freq));
+#endif
 
-	return 1000000.0 / (double)freq;
+    double multiplier = 1000000000.0 / (double)freq;
+	return multiplier;
 }
 #endif
 
 void init_thread(uint32_t _tid, size_t buffer_size, int64_t symbol_cache_size) {
 	uint8_t *buffer = (uint8_t *)malloc(buffer_size);
-	spall_buffer = (SpallBuffer){ .data = buffer, .length = buffer_size };
+	spall_buffer = (SpallBuffer){ .pid = 0, .tid = _tid, .data = buffer, .length = buffer_size };
 
 	// removing initial page-fault bubbles to make the data a little more accurate, at the cost of thread spin-up time
 	memset(buffer, 1, buffer_size);
 
 	spall_buffer_init(&spall_ctx, &spall_buffer);
 
-	tid = _tid;
 	addr_map = ah_init(symbol_cache_size);
 	spall_thread_running = true;
 }
@@ -203,7 +222,7 @@ void exit_thread() {
 }
 
 void init_profile(char *filename) {
-	spall_ctx = spall_init_file(filename, get_rdtsc_multiplier());
+	spall_init_file(filename, get_tick_multiplier(), &spall_ctx);
 }
 
 void exit_profile(void) {
@@ -221,7 +240,7 @@ void __cyg_profile_func_enter(void *fn, void *caller) {
 		name = (Name){.str = not_found, .len = sizeof(not_found) - 1};
 	}
 
-	spall_buffer_begin_ex(&spall_ctx, &spall_buffer, name.str, name.len, __rdtsc(), tid, 0);
+	spall_buffer_begin(&spall_ctx, &spall_buffer, name.str, name.len, get_ticks());
 }
 
 void __cyg_profile_func_exit(void *fn, void *caller) {
@@ -229,5 +248,5 @@ void __cyg_profile_func_exit(void *fn, void *caller) {
 		return;
 	}
 
-	spall_buffer_end_ex(&spall_ctx, &spall_buffer, __rdtsc(), tid, 0);
+	spall_buffer_end(&spall_ctx, &spall_buffer, get_ticks());
 }

--- a/examples/auto_tracing/instrument.c
+++ b/examples/auto_tracing/instrument.c
@@ -201,7 +201,7 @@ SPALL_FN double get_tick_multiplier(void) {
 }
 #endif
 
-void init_thread(uint32_t _tid, size_t buffer_size, int64_t symbol_cache_size) {
+void init_thread(uint32_t _tid, size_t buffer_size, int64_t symbol_cache_size, char *thread_name) {
 	uint8_t *buffer = (uint8_t *)malloc(buffer_size);
 	spall_buffer = (SpallBuffer){ .pid = 0, .tid = _tid, .data = buffer, .length = buffer_size };
 
@@ -209,6 +209,7 @@ void init_thread(uint32_t _tid, size_t buffer_size, int64_t symbol_cache_size) {
 	memset(buffer, 1, buffer_size);
 
 	spall_buffer_init(&spall_ctx, &spall_buffer);
+	spall_buffer_name_thread(&spall_ctx, &spall_buffer, thread_name, strlen(thread_name));
 
 	addr_map = ah_init(symbol_cache_size);
 	spall_thread_running = true;

--- a/examples/auto_tracing/instrument.h
+++ b/examples/auto_tracing/instrument.h
@@ -4,5 +4,5 @@
 
 void init_profile(char *filename);
 void exit_profile(void);
-void init_thread(uint32_t tid, size_t buffer_size, int64_t symbol_cache_size);
+void init_thread(uint32_t tid, size_t buffer_size, int64_t symbol_cache_size, char *thread_name);
 void exit_thread(void);

--- a/examples/auto_tracing/sample_program.c
+++ b/examples/auto_tracing/sample_program.c
@@ -13,10 +13,14 @@ void wub() {
 	printf("Foobar is terrible\n");
 }
 
-void *run_work(void *ptr) {
-	init_thread((uint32_t)(uint64_t)pthread_self(), 10 * 1024 * 1024, 1000);
+#define MAX_CACHED_SYMBOLS 1000
+#define SPALL_BUFFER_SIZE 10 * 1024 * 1024
+#define LOOP_ITERATIONS 5000000
 
-	for (int i = 0; i < 1000; i++) {
+void *run_work(void *ptr) {
+	init_thread((uint32_t)(uint64_t)pthread_self(), SPALL_BUFFER_SIZE, MAX_CACHED_SYMBOLS);
+
+	for (int i = 0; i < LOOP_ITERATIONS; i++) {
 		foo();
 	}
 
@@ -26,13 +30,13 @@ void *run_work(void *ptr) {
 
 int main() {
 	init_profile("profile.spall");
-	init_thread(0, 10 * 1024 * 1024, 1000);
+	init_thread(0, SPALL_BUFFER_SIZE, MAX_CACHED_SYMBOLS);
 
 	pthread_t thread_1, thread_2;
 	pthread_create(&thread_1, NULL, run_work, NULL);
 	pthread_create(&thread_2, NULL, run_work, NULL);
 
-	for (int i = 0; i < 1000; i++) {
+	for (int i = 0; i < LOOP_ITERATIONS; i++) {
 		foo();
 	}
 

--- a/examples/manual_tracing/advanced_threads_example_linux.c
+++ b/examples/manual_tracing/advanced_threads_example_linux.c
@@ -12,7 +12,6 @@
 
 static SpallProfile spall_ctx;
 static _Thread_local SpallBuffer spall_buffer;
-static _Thread_local uint32_t tid;
 
 void *run_work(void *ptr);
 void foo(void);
@@ -20,7 +19,7 @@ void bar(void);
 double get_rdtsc_multiplier(void);
 
 int main() {
-	spall_ctx = spall_init_file("spall_sample.spall", get_rdtsc_multiplier());
+	spall_init_file("spall_sample.spall", get_rdtsc_multiplier(), &spall_ctx);
 
 	pthread_t thread_1, thread_2;
 	pthread_create(&thread_1, NULL, run_work, NULL);
@@ -38,8 +37,6 @@ int main() {
 }
 
 void *run_work(void *ptr) {
-	tid = (uint32_t)pthread_self();
-
 	/*
 		Fun fact: You don't actually *need* a buffer, you can just pass NULL!
 		Passing a buffer clumps flushing overhead, so individual functions are faster and less noisy
@@ -50,6 +47,8 @@ void *run_work(void *ptr) {
 	#define BUFFER_SIZE (100 * 1024 * 1024)
 	unsigned char *buffer = malloc(BUFFER_SIZE);
 	spall_buffer = (SpallBuffer){
+		.pid = 0,
+		.tid = (uint32_t)pthread_self(),
 		.length = BUFFER_SIZE,
 		.data = buffer,
 	};

--- a/examples/manual_tracing/hello_world_example.c
+++ b/examples/manual_tracing/hello_world_example.c
@@ -53,7 +53,7 @@ int main() {
 		.length = buffer_size,
 		.data = buffer,
 	};
-	if (!spall_buffer_init(&spall_buffer)) {
+	if (!spall_buffer_init(&spall_ctx, &spall_buffer)) {
 		printf("Failed to init spall buffer?\n");
 		return 1;
 	}

--- a/formats/spall/spall.odin
+++ b/formats/spall/spall.odin
@@ -21,6 +21,9 @@ Manual_Event_Type :: enum u8 {
 
 	Overwrite_Timestamp = 6, // Retroactively change timestamp units - useful for incrementally improving RDTSC frequency.
 	Pad_Skip            = 7,
+
+	Name_Process        = 8,
+	Name_Thread         = 9,
 }
 
 Manual_Buffer_Header :: struct #packed {
@@ -63,4 +66,9 @@ End_Event_V2 :: struct #packed {
 Pad_Skip :: struct #packed {
 	type: Manual_Event_Type,
 	size: u32,
+}
+
+Name_Container :: struct #packed {
+	type: Manual_Event_Type,
+	name_len: u8,
 }

--- a/formats/spall/spall.odin
+++ b/formats/spall/spall.odin
@@ -3,14 +3,14 @@ package spall
 MANUAL_MAGIC :: u64(0x0BADF00D)
 NATIVE_MAGIC :: u64(0xABADF00D)
 
-Header :: struct #packed {
+Manual_Header :: struct #packed {
 	magic:          u64,
 	version:        u64,
 	timestamp_unit: f64,
 	must_be_0:      u64,
 }
 
-Event_Type :: enum u8 {
+Manual_Event_Type :: enum u8 {
 	Invalid             = 0,
 	Custom_Data         = 1, // Basic readers can skip this.
 	StreamOver          = 2,
@@ -20,10 +20,18 @@ Event_Type :: enum u8 {
 	Instant             = 5,
 
 	Overwrite_Timestamp = 6, // Retroactively change timestamp units - useful for incrementally improving RDTSC frequency.
+	Pad_Skip            = 7,
 }
 
-Begin_Event :: struct #packed {
-	type:     Event_Type,
+Manual_Buffer_Header :: struct #packed {
+	size:     u32,
+	tid:      u32,
+	pid:      u32,
+	first_ts: u64,
+}
+
+Begin_Event_V1 :: struct #packed {
+	type:     Manual_Event_Type,
 	category: u8,
 	pid:      u32,
 	tid:      u32,
@@ -32,9 +40,27 @@ Begin_Event :: struct #packed {
 	args_len: u8,
 }
 
-End_Event :: struct #packed {
-	type: Event_Type,
+End_Event_V1 :: struct #packed {
+	type: Manual_Event_Type,
 	pid:  u32,
 	tid:  u32,
 	time: f64,
+}
+
+
+Begin_Event_V2 :: struct #packed {
+	type: Manual_Event_Type,
+	time: u64,
+	name_len: u8,
+	args_len: u8,
+}
+
+End_Event_V2 :: struct #packed {
+	type: Manual_Event_Type,
+	time: u64,
+}
+
+Pad_Skip :: struct #packed {
+	type: Manual_Event_Type,
+	size: u32,
 }

--- a/spall.h
+++ b/spall.h
@@ -276,7 +276,7 @@ SPALL_FN bool spall_flush(SpallProfile *ctx) {
     return true;
 }
 
-SPALL_FN bool spall_buffer_init(SpallBuffer *wb) {
+SPALL_FN bool spall_buffer_init(SpallProfile *ctx, SpallBuffer *wb) {
 	// Fails if buffer is not big enough to contain at least one event!
 	if (wb->length < sizeof(SpallBufferHeader) + sizeof(SpallBeginEventMax)) {
 		return false;

--- a/spall.h
+++ b/spall.h
@@ -38,14 +38,14 @@ TODO: Optional Helper APIs:
 #include <stdbool.h>
 
 #define SPALL_FN static inline SPALL_NOINSTRUMENT
-
 #define SPALL_MIN(a, b) (((a) < (b)) ? (a) : (b))
+#define SPALL_MAX(a, b) (((a) > (b)) ? (a) : (b))
 
 #pragma pack(push, 1)
 
 typedef struct SpallHeader {
     uint64_t magic_header; // = 0x0BADF00D
-    uint64_t version; // = 1
+    uint64_t version; // = 3
     double   timestamp_unit;
     uint64_t must_be_0;
 } SpallHeader;
@@ -61,15 +61,21 @@ enum {
 
     SpallEventType_Overwrite_Timestamp = 6, // Retroactively change timestamp units - useful for incrementally improving RDTSC frequency.
     SpallEventType_Pad_Skip            = 7,
+
+	SpallEventType_NameThread          = 8,
+	SpallEventType_NameProcess         = 9,
 };
+
+typedef struct SpallBufferHeader {
+	uint32_t size;
+	uint32_t tid;
+	uint32_t pid;
+	uint64_t first_ts;
+} SpallBufferHeader;
 
 typedef struct SpallBeginEvent {
     uint8_t type; // = SpallEventType_Begin
-    uint8_t category;
-
-    uint32_t pid;
-    uint32_t tid;
-    double   when;
+    uint64_t when;
 
     uint8_t name_length;
     uint8_t args_length;
@@ -83,15 +89,23 @@ typedef struct SpallBeginEventMax {
 
 typedef struct SpallEndEvent {
     uint8_t  type; // = SpallEventType_End
-    uint32_t pid;
-    uint32_t tid;
-    double   when;
+    uint64_t when;
 } SpallEndEvent;
 
 typedef struct SpallPadSkipEvent {
     uint8_t  type; // = SpallEventType_Pad_Skip
     uint32_t size;
 } SpallPadSkipEvent;
+
+typedef struct SpallNameContainerEvent {
+	uint8_t type; // = SpallEventType_NameThread/Process
+	uint8_t name_length;
+} SpallNameContainerEvent;
+
+typedef struct SpallNameContainerEventMax {
+    SpallNameContainerEvent event;
+    char name_bytes[255];
+} SpallNameContainerEventMax;
 
 #pragma pack(pop)
 
@@ -104,7 +118,6 @@ typedef void (*SpallCloseCallback)(SpallProfile *self);
 
 struct SpallProfile {
     double timestamp_unit;
-    bool is_json;
     SpallWriteCallback write;
     SpallFlushCallback flush;
     SpallCloseCallback close;
@@ -116,129 +129,54 @@ struct SpallProfile {
 typedef struct SpallBuffer {
     void *data;
     size_t length;
+	uint32_t tid;
+	uint32_t pid;
 
     // Internal data - don't assign this
     size_t head;
-    SpallProfile *ctx;
+	uint64_t first_ts;
 } SpallBuffer;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#if defined(SPALL_BUFFER_PROFILING) && !defined(SPALL_BUFFER_PROFILING_GET_TIME)
-#error "You must #define SPALL_BUFFER_PROFILING_GET_TIME() to profile buffer flushes."
-#endif
-
-SPALL_FN SPALL_FORCEINLINE void spall__buffer_profile(SpallProfile *ctx, SpallBuffer *wb, double spall_time_begin, double spall_time_end, const char *name, int name_len);
-#ifdef SPALL_BUFFER_PROFILING
-#define SPALL_BUFFER_PROFILE_BEGIN() double spall_time_begin = (SPALL_BUFFER_PROFILING_GET_TIME())
-// Don't call this with anything other than a string literal
-#define SPALL_BUFFER_PROFILE_END(name) spall__buffer_profile(ctx, wb, spall_time_begin, (SPALL_BUFFER_PROFILING_GET_TIME()), "" name "", sizeof("" name "") - 1)
-#else
-#define SPALL_BUFFER_PROFILE_BEGIN()
-#define SPALL_BUFFER_PROFILE_END(name)
-#endif
-
 SPALL_FN SPALL_FORCEINLINE bool spall__file_write(SpallProfile *ctx, const void *p, size_t n) {
-    if (!ctx->data) return false;
-#ifdef SPALL_DEBUG
-    if (feof((FILE *)ctx->data)) return false;
-    if (ferror((FILE *)ctx->data)) return false;
-#endif
-
     if (fwrite(p, n, 1, (FILE *)ctx->data) != 1) return false;
     return true;
 }
 SPALL_FN bool spall__file_flush(SpallProfile *ctx) {
-    if (!ctx->data) return false;
     if (fflush((FILE *)ctx->data)) return false;
     return true;
 }
 SPALL_FN void spall__file_close(SpallProfile *ctx) {
-    if (!ctx->data) return;
-
-    if (ctx->is_json) {
-#ifdef SPALL_DEBUG
-        if (!feof((FILE *)ctx->data) && !ferror((FILE *)ctx->data))
-#endif
-        {
-            fseek((FILE *)ctx->data, -2, SEEK_CUR); // seek back to overwrite trailing comma
-            fwrite("\n]}\n", sizeof("\n]}\n") - 1, 1, (FILE *)ctx->data);
-        }
-    }
-    fflush((FILE *)ctx->data);
     fclose((FILE *)ctx->data);
     ctx->data = NULL;
 }
 
-SPALL_FN SPALL_FORCEINLINE bool spall__buffer_flush(SpallProfile *ctx, SpallBuffer *wb) {
-    // precon: wb
-    // precon: wb->data
-    // precon: wb->head <= wb->length
-    // precon: !ctx || ctx->write
-#ifdef SPALL_DEBUG
-    if (wb->ctx != ctx) return false; // Buffer must be bound to this context (or to NULL)
-#endif
+SPALL_FN SPALL_FORCEINLINE bool spall__buffer_flush(SpallProfile *ctx, SpallBuffer *wb, uint64_t ts) {
+	wb->first_ts = SPALL_MAX(wb->first_ts, ts);
 
-    if (wb->head && ctx) {
-        SPALL_BUFFER_PROFILE_BEGIN();
-        if (!ctx->write) return false;
-        if (ctx->write == spall__file_write) {
-            if (!spall__file_write(ctx, wb->data, wb->head)) return false;
-        } else {
-            if (!ctx->write(ctx, wb->data, wb->head)) return false;
-        }
-        SPALL_BUFFER_PROFILE_END("Buffer Flush");
-    }
-    wb->head = 0;
-    return true;
-}
+	SpallBufferHeader hdr;
+	hdr.size = wb->head - sizeof(SpallBufferHeader);
+	hdr.pid = wb->pid;
+	hdr.tid = wb->tid;
+	hdr.first_ts = wb->first_ts;
 
-SPALL_FN SPALL_FORCEINLINE bool spall__buffer_write(SpallProfile *ctx, SpallBuffer *wb, void *p, size_t n) {
-    // precon: !wb || wb->head < wb->length
-    // precon: !ctx || ctx->write
-    if (!wb) return ctx->write && ctx->write(ctx, p, n);
-#ifdef SPALL_DEBUG
-    if (wb->ctx != ctx) return false; // Buffer must be bound to this context (or to NULL)
-#endif
-    if (wb->head + n > wb->length && !spall__buffer_flush(ctx, wb)) return false;
-    if (n > wb->length) {
-        SPALL_BUFFER_PROFILE_BEGIN();
-        if (!ctx->write || !ctx->write(ctx, p, n)) return false;
-        SPALL_BUFFER_PROFILE_END("Unbuffered Write");
-        return true;
-    }
-    memcpy((char *)wb->data + wb->head, p, n);
-    wb->head += n;
+	memcpy(wb->data, &hdr, sizeof(hdr));
+
+	if (!ctx->write(ctx, wb->data, wb->head)) return false;
+    wb->head = sizeof(SpallBufferHeader);
     return true;
 }
 
 SPALL_FN bool spall_buffer_flush(SpallProfile *ctx, SpallBuffer *wb) {
-#ifdef SPALL_DEBUG
-    if (!wb) return false;
-    if (!wb->data) return false;
-#endif
-
-    if (!spall__buffer_flush(ctx, wb)) return false;
+    if (!spall__buffer_flush(ctx, wb, 0)) return false;
     return true;
 }
 
-SPALL_FN bool spall_buffer_init(SpallProfile *ctx, SpallBuffer *wb) {
-    if (!spall_buffer_flush(NULL, wb)) return false;
-    wb->ctx = ctx;
-    return true;
-}
 SPALL_FN bool spall_buffer_quit(SpallProfile *ctx, SpallBuffer *wb) {
     if (!spall_buffer_flush(ctx, wb)) return false;
-    wb->ctx = NULL;
-    return true;
-}
-
-SPALL_FN bool spall_buffer_abort(SpallBuffer *wb) {
-    if (!wb) return false;
-    wb->ctx = NULL;
-    if (!spall__buffer_flush(NULL, wb)) return false;
     return true;
 }
 
@@ -250,12 +188,12 @@ SPALL_FN size_t spall_build_header(void *buffer, size_t rem_size, double timesta
 
     SpallHeader *header = (SpallHeader *)buffer;
     header->magic_header = 0x0BADF00D;
-    header->version = 1;
+    header->version = 3;
     header->timestamp_unit = timestamp_unit;
     header->must_be_0 = 0;
     return header_size;
 }
-SPALL_FN SPALL_FORCEINLINE size_t spall_build_begin(void *buffer, size_t rem_size, const char *name, signed long name_len, const char *args, signed long args_len, double when, uint32_t tid, uint32_t pid) {
+SPALL_FN SPALL_FORCEINLINE size_t spall_build_begin(void *buffer, size_t rem_size, const char *name, int32_t name_len, const char *args, int32_t args_len, uint64_t when) {
     SpallBeginEventMax *ev = (SpallBeginEventMax *)buffer;
     uint8_t trunc_name_len = (uint8_t)SPALL_MIN(name_len, 255); // will be interpreted as truncated in the app (?)
     uint8_t trunc_args_len = (uint8_t)SPALL_MIN(args_len, 255); // will be interpreted as truncated in the app (?)
@@ -266,9 +204,6 @@ SPALL_FN SPALL_FORCEINLINE size_t spall_build_begin(void *buffer, size_t rem_siz
     }
 
     ev->event.type = SpallEventType_Begin;
-    ev->event.category = 0;
-    ev->event.pid = pid;
-    ev->event.tid = tid;
     ev->event.when = when;
     ev->event.name_length = trunc_name_len;
     ev->event.args_length = trunc_args_len;
@@ -277,7 +212,7 @@ SPALL_FN SPALL_FORCEINLINE size_t spall_build_begin(void *buffer, size_t rem_siz
 
     return ev_size;
 }
-SPALL_FN SPALL_FORCEINLINE size_t spall_build_end(void *buffer, size_t rem_size, double when, uint32_t tid, uint32_t pid) {
+SPALL_FN SPALL_FORCEINLINE size_t spall_build_end(void *buffer, size_t rem_size, uint64_t when) {
     size_t ev_size = sizeof(SpallEndEvent);
     if (ev_size > rem_size) {
         return 0;
@@ -285,8 +220,6 @@ SPALL_FN SPALL_FORCEINLINE size_t spall_build_end(void *buffer, size_t rem_size,
 
     SpallEndEvent *ev = (SpallEndEvent *)buffer;
     ev->type = SpallEventType_End;
-    ev->pid = pid;
-    ev->tid = tid;
     ev->when = when;
 
     return ev_size;
@@ -299,133 +232,86 @@ SPALL_FN void spall_quit(SpallProfile *ctx) {
     memset(ctx, 0, sizeof(*ctx));
 }
 
-SPALL_FN SpallProfile spall_init_callbacks(double timestamp_unit,
-                                           SpallWriteCallback write,
-                                           SpallFlushCallback flush,
-                                           SpallCloseCallback close,
-                                           void *userdata,
-                                           bool is_json) {
-    SpallProfile ctx;
-    memset(&ctx, 0, sizeof(ctx));
-    if (timestamp_unit < 0) return ctx;
-    ctx.timestamp_unit = timestamp_unit;
-    ctx.is_json = is_json;
-    ctx.data = userdata;
-    ctx.write = write;
-    ctx.flush = flush;
-    ctx.close = close;
+SPALL_FN bool spall_init_callbacks(double timestamp_unit,
+								   SpallWriteCallback write,
+								   SpallFlushCallback flush,
+								   SpallCloseCallback close,
+								   void *userdata,
+								   SpallProfile *ctx) {
 
-    if (ctx.is_json) {
-        if (!ctx.write(&ctx, "{\"traceEvents\":[\n", sizeof("{\"traceEvents\":[\n") - 1)) { spall_quit(&ctx); return ctx; }
-    } else {
-        SpallHeader header;
-        size_t len = spall_build_header(&header, sizeof(header), timestamp_unit);
-        if (!ctx.write(&ctx, &header, len)) { spall_quit(&ctx); return ctx; }
-    }
+    if (timestamp_unit < 0) return false;
 
-    return ctx;
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->timestamp_unit = timestamp_unit;
+    ctx->data = userdata;
+    ctx->write = write;
+    ctx->flush = flush;
+    ctx->close = close;
+
+	SpallHeader header;
+	size_t len = spall_build_header(&header, sizeof(header), timestamp_unit);
+	if (!ctx->write(ctx, &header, len)) {
+		spall_quit(ctx);
+		return false;
+	}
+
+    return true;
 }
 
-SPALL_FN SpallProfile spall_init_file_ex(const char *filename, double timestamp_unit, bool is_json) {
-    SpallProfile ctx;
-    memset(&ctx, 0, sizeof(ctx));
-    if (!filename) return ctx;
-    ctx.data = fopen(filename, "wb"); // TODO: handle utf8 and long paths on windows
-    if (ctx.data) { // basically freopen() but we don't want to force users to lug along another macro define
-        fclose((FILE *)ctx.data);
-        ctx.data = fopen(filename, "ab");
-    }
-    if (!ctx.data) { spall_quit(&ctx); return ctx; }
-    ctx = spall_init_callbacks(timestamp_unit, spall__file_write, spall__file_flush, spall__file_close, ctx.data, is_json);
-    return ctx;
-}
+SPALL_FN bool spall_init_file(const char* filename, double timestamp_unit, SpallProfile *ctx) {
+    if (!filename) return false;
 
-SPALL_FN SpallProfile spall_init_file     (const char* filename, double timestamp_unit) { return spall_init_file_ex(filename, timestamp_unit, false); }
-SPALL_FN SpallProfile spall_init_file_json(const char* filename, double timestamp_unit) { return spall_init_file_ex(filename, timestamp_unit, true); }
+    FILE *f = fopen(filename, "wb"); // TODO: handle utf8 and long paths on windows
+    if (f) { // basically freopen() but we don't want to force users to lug along another macro define
+        fclose(f);
+        f = fopen(filename, "ab");
+    }
+	if (!f) { return false; }
+
+    return spall_init_callbacks(timestamp_unit, spall__file_write, spall__file_flush, spall__file_close, (void *)f, ctx);
+}
 
 SPALL_FN bool spall_flush(SpallProfile *ctx) {
-#ifdef SPALL_DEBUG
-    if (!ctx) return false;
-#endif
-
-    if (!ctx->flush || !ctx->flush(ctx)) return false;
+    if (!ctx->flush(ctx)) return false;
     return true;
 }
 
-SPALL_FN SPALL_FORCEINLINE bool spall_buffer_begin_args(SpallProfile *ctx, SpallBuffer *wb, const char *name, signed long name_len, const char *args, signed long args_len, double when, uint32_t tid, uint32_t pid) {
-#ifdef SPALL_DEBUG
-    if (!ctx) return false;
-    if (!name) return false;
-    if (name_len <= 0) return false;
-    if (!wb) return false;
-#endif
+SPALL_FN bool spall_buffer_init(SpallBuffer *wb) {
+	// Fails if buffer is not big enough to contain at least one event!
+	if (wb->length < sizeof(SpallBufferHeader) + sizeof(SpallBeginEventMax)) {
+		return false;
+	}
 
-    if (ctx->is_json) {
-        char buf[1024];
-        int buf_len = snprintf(buf, sizeof(buf),
-                               "{\"ph\":\"B\",\"ts\":%f,\"pid\":%u,\"tid\":%u,\"name\":\"%.*s\",\"args\":\"%.*s\"},\n",
-                               when * ctx->timestamp_unit, pid, tid, (int)(uint8_t)name_len, name, (int)(uint8_t)args_len, args);
-        if (buf_len <= 0) return false;
-        if (buf_len >= sizeof(buf)) return false;
-        if (!spall__buffer_write(ctx, wb, buf, buf_len)) return false;
-    } else {
-        if ((wb->head + sizeof(SpallBeginEventMax)) > wb->length) {
-            if (!spall__buffer_flush(ctx, wb)) {
-                return false;
-            }
-        }
+	wb->head = sizeof(SpallBufferHeader);
+	return true;
+}
 
-        wb->head += spall_build_begin((char *)wb->data + wb->head, wb->length - wb->head, name, name_len, args, args_len, when, tid, pid);
-    }
+
+SPALL_FN SPALL_FORCEINLINE bool spall_buffer_begin_args(SpallProfile *ctx, SpallBuffer *wb, const char *name, int32_t name_len, const char *args, int32_t args_len, uint64_t when) {
+	if ((wb->head + sizeof(SpallBeginEventMax)) > wb->length) {
+		if (!spall__buffer_flush(ctx, wb, when)) {
+			return false;
+		}
+	}
+
+	wb->head += spall_build_begin((char *)wb->data + wb->head, wb->length - wb->head, name, name_len, args, args_len, when);
 
     return true;
 }
 
-SPALL_FN SPALL_FORCEINLINE bool spall_buffer_begin_ex(SpallProfile *ctx, SpallBuffer *wb, const char *name, signed long name_len, double when, uint32_t tid, uint32_t pid) {
-    return spall_buffer_begin_args(ctx, wb, name, name_len, "", 0, when, tid, pid);
+SPALL_FN bool spall_buffer_begin(SpallProfile *ctx, SpallBuffer *wb, const char *name, int32_t name_len, uint64_t when) {
+    return spall_buffer_begin_args(ctx, wb, name, name_len, "", 0, when);
 }
 
-SPALL_FN bool spall_buffer_begin(SpallProfile *ctx, SpallBuffer *wb, const char *name, signed long name_len, double when) {
-    return spall_buffer_begin_args(ctx, wb, name, name_len, "", 0, when, 0, 0);
-}
+SPALL_FN bool spall_buffer_end(SpallProfile *ctx, SpallBuffer *wb, uint64_t when) {
+	if ((wb->head + sizeof(SpallEndEvent)) > wb->length) {
+		if (!spall__buffer_flush(ctx, wb, when)) {
+			return false;
+		}
+	}
 
-SPALL_FN SPALL_FORCEINLINE bool spall_buffer_end_ex(SpallProfile *ctx, SpallBuffer *wb, double when, uint32_t tid, uint32_t pid) {
-#ifdef SPALL_DEBUG
-    if (!ctx) return false;
-    if (!wb) return false;
-#endif
-
-    if (ctx->is_json) {
-        char buf[512];
-        int buf_len = snprintf(buf, sizeof(buf),
-                               "{\"ph\":\"E\",\"ts\":%f,\"pid\":%u,\"tid\":%u},\n",
-                               when * ctx->timestamp_unit, pid, tid);
-        if (buf_len <= 0) return false;
-        if (buf_len >= sizeof(buf)) return false;
-        if (!spall__buffer_write(ctx, wb, buf, buf_len)) return false;
-    } else {
-        if ((wb->head + sizeof(SpallEndEvent)) > wb->length) {
-            if (!spall__buffer_flush(ctx, wb)) {
-                return false;
-            }
-        }
-
-        wb->head += spall_build_end((char *)wb->data + wb->head, wb->length - wb->head, when, tid, pid);
-    }
-
-    return true;
-}
-
-SPALL_FN bool spall_buffer_end(SpallProfile *ctx, SpallBuffer *wb, double when) { return spall_buffer_end_ex(ctx, wb, when, 0, 0); }
-
-SPALL_FN SPALL_FORCEINLINE void spall__buffer_profile(SpallProfile *ctx, SpallBuffer *wb, double spall_time_begin, double spall_time_end, const char *name, int name_len) {
-    // precon: ctx
-    // precon: ctx->write
-    char temp_buffer_data[2048];
-    SpallBuffer temp_buffer = { temp_buffer_data, sizeof(temp_buffer_data) };
-    if (!spall_buffer_begin_ex(ctx, &temp_buffer, name, name_len, spall_time_begin, (uint32_t)(uintptr_t)wb->data, 4222222222)) return;
-    if (!spall_buffer_end_ex(ctx, &temp_buffer, spall_time_end, (uint32_t)(uintptr_t)wb->data, 4222222222)) return;
-    if (ctx->write) ctx->write(ctx, temp_buffer_data, temp_buffer.head);
+	wb->head += spall_build_end((char *)wb->data + wb->head, wb->length - wb->head, when);
+	return true;
 }
 
 #ifdef __cplusplus

--- a/src/manual_stream_parse.odin
+++ b/src/manual_stream_parse.odin
@@ -366,10 +366,7 @@ ms_v2_load_binary_chunk :: proc(trace: ^Trace, chunk: []u8) {
 				ev.args = temp_ev.args
 				ev.duration = -1
 				ev.self_time = 0 
-				ev.timestamp = max(temp_ev.timestamp, thread.zero_patchup)
-				if ev.timestamp > thread.zero_patchup {
-					thread.zero_patchup = -1
-				}
+				ev.timestamp = max(i64(temp_ev.timestamp), thread.zero_patchup)
 
 				if thread.max_time > ev.timestamp {
 					fmt.printf("Woah, time-travel? You just had a begin event that started before a previous one; [pid: %d, tid: %d, name: %s]\n", 
@@ -407,15 +404,11 @@ ms_v2_load_binary_chunk :: proc(trace: ^Trace, chunk: []u8) {
 
 					depth := &thread.depths[thread.current_depth]
 					jev := &depth.events[jev_data.idx]
-					jev.duration = temp_ev.timestamp - jev.timestamp
+					jev.duration = i64(temp_ev.timestamp) - jev.timestamp
 					if jev.duration == 0 {
-						if thread.zero_patchup == -1 {
-							thread.zero_patchup = i64(temp_ev.timestamp)
-						}
+						thread.zero_patchup = i64(temp_ev.timestamp)
 						thread.zero_patchup += 1
 						jev.duration = 1
-					} else {
-						thread.zero_patchup = -1
 					}
 
 					jev.self_time = jev.duration - jev.self_time

--- a/src/manual_stream_parse.odin
+++ b/src/manual_stream_parse.odin
@@ -36,14 +36,14 @@ ms_v1_get_next_event :: proc(trace: ^Trace, chunk: []u8, temp_ev: ^TempEvent) ->
 	}
 
 	data_start := chunk[chunk_pos(p):]
-	type := (^spall.Event_Type)(raw_data(data_start))^
+	type := (^spall.Manual_Event_Type)(raw_data(data_start))^
 	#partial switch type {
 	case .Begin:
-		event_sz := i64(size_of(spall.Begin_Event))
+		event_sz := i64(size_of(spall.Begin_Event_V1))
 		if chunk_pos(p) + event_sz > i64(len(chunk)) {
 			return .PartialRead
 		}
-		event := (^spall.Begin_Event)(raw_data(data_start))
+		event := (^spall.Begin_Event_V1)(raw_data(data_start))
 
 		event_tail := i64(event.name_len) + i64(event.args_len)
 		if (chunk_pos(p) + event_sz + event_tail) > i64(len(chunk)) {
@@ -63,11 +63,11 @@ ms_v1_get_next_event :: proc(trace: ^Trace, chunk: []u8, temp_ev: ^TempEvent) ->
 		p.pos += event_sz + event_tail
 		return .EventRead
 	case .End:
-		event_sz := i64(size_of(spall.End_Event))
+		event_sz := i64(size_of(spall.End_Event_V1))
 		if chunk_pos(p) + event_sz > i64(len(chunk)) {
 			return .PartialRead
 		}
-		event := (^spall.End_Event)(raw_data(data_start))
+		event := (^spall.End_Event_V1)(raw_data(data_start))
 
 		temp_ev.type = .End
 		temp_ev.timestamp = i64(event.time)
@@ -237,21 +237,91 @@ ms_v1_bin_process_events :: proc(trace: ^Trace) {
 	return
 }
 
+ms_v2_get_buffer_header :: proc(trace: ^Trace, chunk: []u8, hdr: ^spall.Manual_Buffer_Header) -> BinaryState {
+	p := &trace.parser
+	header_sz := i64(size_of(spall.Manual_Buffer_Header))
+	if chunk_pos(p) + header_sz > i64(len(chunk)) {
+		return .PartialRead
+	}
+
+	data_start := chunk[chunk_pos(p):]
+	tmp_hdr := (^spall.Manual_Buffer_Header)(raw_data(data_start))^
+	if chunk_pos(p) + header_sz + i64(tmp_hdr.size) > i64(len(chunk)) {
+		return .PartialRead
+	}
+
+	hdr^ = tmp_hdr
+	p.pos += size_of(spall.Manual_Buffer_Header)
+
+	return .EventRead
+}
+
+ms_v2_get_next_event :: proc(trace: ^Trace, chunk: []u8, temp_ev: ^TempEvent) -> BinaryState {
+	p := &trace.parser
+
+	header_sz := i64(size_of(u64))
+	if chunk_pos(p) + header_sz > i64(len(chunk)) {
+		return .PartialRead
+	}
+
+	data_start := chunk[chunk_pos(p):]
+	type := (^spall.Manual_Event_Type)(raw_data(data_start))^
+	#partial switch type {
+	case .Begin:
+		event_sz := i64(size_of(spall.Begin_Event_V2))
+		if chunk_pos(p) + event_sz > i64(len(chunk)) {
+			return .PartialRead
+		}
+		event := (^spall.Begin_Event_V2)(raw_data(data_start))
+
+		event_tail := i64(event.name_len) + i64(event.args_len)
+		if (chunk_pos(p) + event_sz + event_tail) > i64(len(chunk)) {
+			return .PartialRead
+		}
+
+		name := string(data_start[event_sz:event_sz+i64(event.name_len)])
+		args := string(data_start[event_sz+i64(event.name_len):event_sz+i64(event.name_len)+i64(event.args_len)])
+
+		temp_ev.type = .Begin
+		temp_ev.timestamp = i64(event.time)
+		temp_ev.name = in_get(&trace.intern, &trace.string_block, name)
+		temp_ev.args = in_get(&trace.intern, &trace.string_block, args)
+
+		p.pos += event_sz + event_tail
+		return .EventRead
+	case .End:
+		event_sz := i64(size_of(spall.End_Event_V2))
+		if chunk_pos(p) + event_sz > i64(len(chunk)) {
+			return .PartialRead
+		}
+		event := (^spall.End_Event_V2)(raw_data(data_start))
+
+		temp_ev.type = .End
+		temp_ev.timestamp = i64(event.time)
+		
+		p.pos += event_sz
+		return .EventRead
+	case:
+		return .Failure
+	}
+
+	return .PartialRead
+}
+
 ms_v2_load_binary_chunk :: proc(trace: ^Trace, chunk: []u8) {
 	p := &trace.parser
 	temp_ev := TempEvent{}
 	ev := Event{}
+	hdr := spall.Manual_Buffer_Header{}
 
 	full_chunk := chunk
-	load_loop: for p.pos < i64(p.total_size) {
-		mem.zero(&temp_ev, size_of(TempEvent))
-		state := ms_v1_get_next_event(trace, full_chunk, &temp_ev)
 
+	load_loop: for p.pos < i64(p.total_size) {
+		state := ms_v2_get_buffer_header(trace, full_chunk, &hdr)
 		#partial switch state {
 		case .PartialRead:
 			if p.pos == last_read {
-				fmt.printf("Invalid trailing data? dropping from [%d -> %d] (%d bytes)\n", p.pos, p.total_size, i64(p.total_size) - p.pos)
-				break load_loop
+				push_fatal(SpallError.InvalidFile)
 			} else {
 				last_read = p.pos
 			}
@@ -260,57 +330,109 @@ ms_v2_load_binary_chunk :: proc(trace: ^Trace, chunk: []u8) {
 			get_chunk(f64(p.pos), f64(CHUNK_SIZE))
 			return
 		case .Failure:
+			fmt.printf("invalid buffer?\n")
 			push_fatal(SpallError.InvalidFile)
 		}
 
-		#partial switch temp_ev.type {
-		case .Begin:
-			ev.name = temp_ev.name
-			ev.args = temp_ev.args
-			ev.duration = -1
-			ev.self_time = 0 
-			ev.timestamp = temp_ev.timestamp
+		p_idx := setup_pid(trace, hdr.pid)
+		t_idx := setup_tid(trace, p_idx, hdr.tid)
+		process := &trace.processes[p_idx]
+		thread := &process.threads[t_idx]
 
-			p_idx, t_idx, e_idx := ms_v1_bin_push_event(trace, temp_ev.process_id, temp_ev.thread_id, &ev)
+		buffer_end := p.pos + i64(hdr.size)
+		for p.pos < buffer_end {
+			mem.zero(&temp_ev, size_of(TempEvent))
+			state := ms_v2_get_next_event(trace, full_chunk, &temp_ev)
 
-			thread := &trace.processes[p_idx].threads[t_idx]
-			stack_push_back(&thread.bande_q, EVData{idx = e_idx, depth = thread.current_depth - 1, self_time = 0})
+			#partial switch state {
+			case .PartialRead:
+				if p.pos == last_read {
+					fmt.printf("Invalid trailing data? dropping from [%d -> %d] (%d bytes)\n", p.pos, p.total_size, i64(p.total_size) - p.pos)
+					break load_loop
+				} else {
+					last_read = p.pos
+				}
 
-			trace.event_count += 1
-		case .End:
-			p_idx, ok1 := vh_find(&trace.process_map, temp_ev.process_id)
-			if !ok1 {
-				fmt.printf("invalid end?\n")
-				continue
+				p.offset = p.pos
+				get_chunk(f64(p.pos), f64(CHUNK_SIZE))
+				return
+			case .Failure:
+				push_fatal(SpallError.InvalidFile)
 			}
-			t_idx, ok2 := vh_find(&trace.processes[p_idx].thread_map, temp_ev.thread_id)
-			if !ok1 {
-				fmt.printf("invalid end?\n")
-				continue
-			}
 
-			thread := &trace.processes[p_idx].threads[t_idx]
-			if thread.bande_q.len > 0 {
-				jev_data := stack_pop_back(&thread.bande_q)
-				thread.current_depth -= 1
+			#partial switch temp_ev.type {
+			case .Begin:
+				ev.name = temp_ev.name
+				ev.args = temp_ev.args
+				ev.duration = -1
+				ev.self_time = 0 
+				ev.timestamp = max(temp_ev.timestamp, thread.zero_patchup)
+				if ev.timestamp > thread.zero_patchup {
+					thread.zero_patchup = -1
+				}
+
+				if thread.max_time > ev.timestamp {
+					fmt.printf("Woah, time-travel? You just had a begin event that started before a previous one; [pid: %d, tid: %d, name: %s]\n", 
+						hdr.pid, hdr.tid, in_getstr(&trace.string_block, ev.name))
+					push_fatal(SpallError.InvalidFile)
+				}
+
+				process.min_time = min(process.min_time, ev.timestamp)
+				thread.min_time = min(thread.min_time, ev.timestamp)
+				thread.max_time = ev.timestamp
+
+				trace.total_min_time = min(trace.total_min_time, ev.timestamp)
+				trace.total_max_time = max(trace.total_max_time, ev.timestamp)
+
+				if int(thread.current_depth) >= len(thread.depths) {
+					depth := Depth{
+						events = make([dynamic]Event, big_global_allocator),
+					}
+					non_zero_append(&thread.depths, depth)
+				}
 
 				depth := &thread.depths[thread.current_depth]
-				jev := &depth.events[jev_data.idx]
-				jev.duration = temp_ev.timestamp - jev.timestamp
-				jev.self_time = jev.duration - jev.self_time
-				thread.max_time = max(thread.max_time, jev.timestamp + jev.duration)
-				trace.total_max_time = max(trace.total_max_time, jev.timestamp + jev.duration)
+				thread.current_depth += 1
+				append_event(&depth.events, ev)
 
+				e_idx := i32(len(depth.events)-1)
+				stack_push_back(&thread.bande_q, EVData{idx = e_idx, depth = thread.current_depth - 1, self_time = 0})
+
+				trace.event_count += 1
+			case .End:
+				temp_ev.timestamp = max(i64(temp_ev.timestamp), thread.zero_patchup)
 				if thread.bande_q.len > 0 {
-					parent_depth := &thread.depths[thread.current_depth - 1]
-					parent_ev := stack_peek_back(&thread.bande_q)
+					jev_data := stack_pop_back(&thread.bande_q)
+					thread.current_depth -= 1
 
-					pev := &parent_depth.events[parent_ev.idx]
+					depth := &thread.depths[thread.current_depth]
+					jev := &depth.events[jev_data.idx]
+					jev.duration = temp_ev.timestamp - jev.timestamp
+					if jev.duration == 0 {
+						if thread.zero_patchup == -1 {
+							thread.zero_patchup = i64(temp_ev.timestamp)
+						}
+						thread.zero_patchup += 1
+						jev.duration = 1
+					} else {
+						thread.zero_patchup = -1
+					}
 
-					pev.self_time += jev.duration
+					jev.self_time = jev.duration - jev.self_time
+					thread.max_time = max(thread.max_time, jev.timestamp + jev.duration)
+					trace.total_max_time = max(trace.total_max_time, jev.timestamp + jev.duration)
+
+					if thread.bande_q.len > 0 {
+						parent_depth := &thread.depths[thread.current_depth - 1]
+						parent_ev := stack_peek_back(&thread.bande_q)
+
+						pev := &parent_depth.events[parent_ev.idx]
+
+						pev.self_time += jev.duration
+					}
+				} else {
+					fmt.printf("Got unexpected end event! [pid: %d, tid: %d, ts: %f]\n", temp_ev.process_id, temp_ev.thread_id, temp_ev.timestamp)
 				}
-			} else {
-				fmt.printf("Got unexpected end event! [pid: %d, tid: %d, ts: %f]\n", temp_ev.process_id, temp_ev.thread_id, temp_ev.timestamp)
 			}
 		}
 	}

--- a/src/types.odin
+++ b/src/types.odin
@@ -283,6 +283,7 @@ Thread :: struct {
 	instants: [dynamic]Instant,
 
 	bande_q: Stack(EVData),
+	zero_patchup: i64,
 }
 
 Process :: struct {
@@ -323,6 +324,7 @@ init_thread :: proc(thread_id: u32) -> Thread {
 		depths = make([dynamic]Depth, small_global_allocator),
 		instants = make([dynamic]Instant, big_global_allocator),
 		in_stats = true,
+		zero_patchup = -1,
 	}
 
 	stack_init(&t.bande_q, scratch_allocator)

--- a/src/types.odin
+++ b/src/types.odin
@@ -173,6 +173,7 @@ EventType :: enum u8 {
 	Begin,
 	End,
 	Metadata,
+	SetName,
 	Sample,
 }
 EventScope :: enum u8 {


### PR DESCRIPTION
Shrinks trace sizes, adds support for naming threads and processes, should also improve load times a little, cleans up the spall.h header and drops support for JSON output